### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/deploy-client-docker.yml
+++ b/.github/workflows/deploy-client-docker.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     
     - name: Run Tests
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         RUN_TESTS: true
       with:

--- a/.github/workflows/deploy-relay-server.yml
+++ b/.github/workflows/deploy-relay-server.yml
@@ -19,7 +19,7 @@ jobs:
         RUST_LOG: debug
 
     - name: Publish to Docker Hub
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: timetoogo/tunshell-relay
         dockerfile: tunshell-server/docker/prod.Dockerfile


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore